### PR TITLE
Docker flag '-f' deprecated

### DIFF
--- a/identijenk/jenkins_shell
+++ b/identijenk/jenkins_shell
@@ -20,8 +20,8 @@ if [ $ERR -eq0 ]; then
   if [ $CODE -eq 200 ]; then
     echo "Test passed - Tagging"
     HASH=$(git rev-parse --short HEAD)
-    sudo docker tag -f jenkins_identidock amouat/identidock:$HASH
-    sudo docker tag -f jenkins_identidock amouat/identidock:newest
+    sudo docker tag jenkins_identidock amouat/identidock:$HASH
+    sudo docker tag jenkins_identidock amouat/identidock:newest
     echo "Pushing"
     sudo docker login -e joe@bloggs.com -u jbloggs -p jbloggs123
     sudo docker push amouat/identidock:$HASH


### PR DESCRIPTION
Page 130, the docker flag `-f` has been deprecated from `docker tag` and will throw Jenkins error `unknown shorthand flag: 'f' in -f` without removing the flag. 
https://github.com/moby/moby/pull/18350
